### PR TITLE
Web security changes

### DIFF
--- a/src/main/java/com/bfwg/config/WebSecurityConfig.java
+++ b/src/main/java/com/bfwg/config/WebSecurityConfig.java
@@ -63,9 +63,6 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        List<RequestMatcher> csrfMethods = new ArrayList<>();
-        Arrays.asList( "POST", "PUT", "PATCH", "DELETE" )
-                .forEach( method -> csrfMethods.add( new AntPathRequestMatcher( "/**", method ) ) );
         http
                 .sessionManagement().sessionCreationPolicy( SessionCreationPolicy.STATELESS ).and()
                 .exceptionHandling().authenticationEntryPoint( restAuthenticationEntryPoint ).and()

--- a/src/main/java/com/bfwg/config/WebSecurityConfig.java
+++ b/src/main/java/com/bfwg/config/WebSecurityConfig.java
@@ -70,16 +70,6 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .sessionManagement().sessionCreationPolicy( SessionCreationPolicy.STATELESS ).and()
                 .exceptionHandling().authenticationEntryPoint( restAuthenticationEntryPoint ).and()
                 .authorizeRequests()
-                .antMatchers(
-                        HttpMethod.GET,
-                        "/",
-                        "/webjars/**",
-                        "/*.html",
-                        "/favicon.ico",
-                        "/**/*.html",
-                        "/**/*.css",
-                        "/**/*.js"
-                ).permitAll()
                 .antMatchers("/auth/**").permitAll()
                 .anyRequest().authenticated().and()
                 .addFilterBefore(new TokenAuthenticationFilter(tokenHelper, jwtUserDetailsService), BasicAuthenticationFilter.class);


### PR DESCRIPTION
Remove used HttpSecurity configurations.

The static path antMachers is not getting used anymore since we have ignored them in the `web.ignore` method.
