### PR TITLE
Updrade docker configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN mvn -B -f pom.xml -s /usr/share/maven/ref/settings-docker.xml dependency:res
 COPY . .
 RUN mvn -B -s /usr/share/maven/ref/settings-docker.xml package
 
-FROM java:8-jdk-alpine
+FROM openjdk:14-alpine
 RUN adduser -Dh /home/bfwg bfwg
 WORKDIR /app
 COPY --from=maven-container /usr/src/app/target/demo-0.1.0-SNAPSHOT.jar .


### PR DESCRIPTION
Fix docker configuration to use an image of java 14 instead of 8 as run image.
The current configuration is broken