### PR TITLE
Could com.example:demo:0.1.0-SNAPSHOT drop off redundant dependencies?

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 			<exclusions>
 			        <exclusion>
+					<!-- bloated dependency -->
 					 <artifactId>tomcat-embed-el</artifactId>
 					 <groupId>org.apache.tomcat.embed</groupId>
 			         </exclusion>
@@ -45,6 +46,7 @@
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 			<exclusions>
 				<exclusion>
+					<!-- bloated dependency -->
 					 <artifactId>txw2</artifactId>
 					 <groupId>org.glassfish.jaxb</groupId>
 				</exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+			<exclusions>
+			        <exclusion>
+					 <artifactId>tomcat-embed-el</artifactId>
+					 <groupId>org.apache.tomcat.embed</groupId>
+			         </exclusion>
+		        </exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -37,6 +43,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
+			<exclusions>
+				<exclusion>
+					 <artifactId>txw2</artifactId>
+					 <groupId>org.glassfish.jaxb</groupId>
+				</exclusion>
+		        </exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.mobile</groupId>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/126549527/234153496-b4b712a3-b3fd-40df-b86a-8b5b4ba3b12d.png)
![image](https://user-images.githubusercontent.com/126549527/234153566-97327bf1-fb47-4caf-8c32-e0ddf84ea3ca.png)

Hi, I found that **_com.example:demo:0.1.0-SNAPSHOT_**’s pom file introduced **_102_** dependencies. However, among them,**_2_** libraries (**_2%_** have not been used by your project), the redundant dependencies are listed below.

Reduce these unused dependencies can help prevent introducing bugs/vulnerabilities from dependencies. Meanwhile, it can minimize the project size. To safely remove redundant dependencies, I constructed a complete call graph (resolved most of Java reflection and dynamic binding), and validated that they have not been used by the client code.

This PR **_com.example:demo:0.1.0-SNAPSHOT_** for removing the redundant dependencies have passed the tests.

Best regards

## Redundant dependencies
#### Redundant indirect dependencies:
        org.apache.tomcat.embed:tomcat-embed-el:9.0.68:compile [250 KB]
        org.glassfish.jaxb:txw2:2.3.7:compile [70 KB]